### PR TITLE
Replaces Base58Check external dependency with embedded modules

### DIFF
--- a/lib/block_keys/base58/base58.ex
+++ b/lib/block_keys/base58/base58.ex
@@ -1,7 +1,9 @@
-defmodule Base58 do
+defmodule BlockKeys.Base58 do
   @moduledoc """
   Documentation for Base58.
   """
+
+  alias BlockKeys.Base58
 
   defdelegate encode(data, hash \\ ""), to: Base58.Encoder
   defdelegate decode(data), to: Base58.Encoder

--- a/lib/block_keys/base58/base58.ex
+++ b/lib/block_keys/base58/base58.ex
@@ -1,0 +1,11 @@
+defmodule Base58 do
+  @moduledoc """
+  Documentation for Base58.
+  """
+
+  defdelegate encode(data, hash \\ ""), to: Base58.Encoder
+  defdelegate decode(data), to: Base58.Encoder
+
+  defdelegate encode_check(data, prefix), to: Base58.Check
+  defdelegate decode_check(data, length \\ 25), to: Base58.Check
+end

--- a/lib/block_keys/base58/check.ex
+++ b/lib/block_keys/base58/check.ex
@@ -1,0 +1,80 @@
+defmodule Base58.Check do
+  # Based on https://github.com/lukaszsamson/base58check/blob/master/lib/base58check.ex
+
+  alias Base58.Encoder
+
+  def encode_check(data, prefix) when is_binary(data) and is_binary(prefix) do
+    data
+    |> maybe_decode_hex() 
+    |> encode(prefix)
+  end
+  def encode_check(data, prefix) do
+    prefix = encode_unsigned(prefix)
+    data = encode_unsigned(data)
+
+    encode_check(data, prefix)
+  end
+
+  defp encode_unsigned(data) when is_integer(data), do: :binary.encode_unsigned(data)
+  defp encode_unsigned(data), do: data
+
+  defp maybe_decode_hex(data) do
+    case Base.decode16(String.upcase(data)) do
+      {:ok, bin} -> bin
+      :error     -> data
+    end
+  end
+
+  defp encode(data, prefix) do
+    (prefix <> data <> generate_checksum(data, prefix))
+    |> Encoder.encode()
+  end
+
+  defp generate_checksum(data, prefix) do
+    (prefix <> data)
+    |> sha256
+    |> sha256
+    |> split
+  end
+
+  defp split(<<checksum::bytes-size(4), _::binary-size(28)>>), do: checksum
+
+  defp sha256(data), do: :crypto.hash(:sha256, data)
+
+  def decode_check(data, length \\ 25) do
+    decoded = Encoder.decode(data) |> :binary.encode_unsigned()
+    size = byte_size(decoded)
+    checksum_size = 4
+    payload_size = length - 5
+
+    if size < checksum_size do
+      raise ArgumentError, "address of size #{size} is too short, expected at least #{checksum_size}"
+    end
+    if size > length do
+      raise ArgumentError, "address of size #{size} is too long, expected #{length}"
+    end
+
+
+    padding = 
+      if size < length do
+        for _ <- 1..(length - size), into: <<>>, do: <<0>>
+      else
+        <<>>
+      end
+
+    <<
+      prefix::binary-size(1),
+      payload::binary-size(payload_size),
+      checksum::binary-size(checksum_size)
+    >> = padding <> decoded
+
+    generated_checksum = generate_checksum(payload, prefix)
+
+    case valid_checksum?(generated_checksum, checksum) do
+      false -> raise ArgumentError, "Checksum is not valid!"
+      true  -> {prefix, data}
+    end
+  end
+
+  defp valid_checksum?(data, checksum), do: data == checksum
+end

--- a/lib/block_keys/base58/check.ex
+++ b/lib/block_keys/base58/check.ex
@@ -1,7 +1,7 @@
-defmodule Base58.Check do
+defmodule BlockKeys.Base58.Check do
   # Based on https://github.com/lukaszsamson/base58check/blob/master/lib/base58check.ex
 
-  alias Base58.Encoder
+  alias BlockKeys.Base58.Encoder
 
   def encode_check(data, prefix) when is_binary(data) and is_binary(prefix) do
     data
@@ -72,7 +72,7 @@ defmodule Base58.Check do
 
     case valid_checksum?(generated_checksum, checksum) do
       false -> raise ArgumentError, "Checksum is not valid!"
-      true  -> {prefix, data}
+      true  -> {prefix, payload}
     end
   end
 

--- a/lib/block_keys/base58/encoder.ex
+++ b/lib/block_keys/base58/encoder.ex
@@ -1,0 +1,50 @@
+defmodule Base58.Encoder do
+  @btc_alphabet '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+  @xrp_alphabet 'rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz'
+
+  # TODO: add alphabet selection
+  def alphabet, do: @btc_alphabet
+
+  def encode(data, hash \\ "")
+  
+  def encode(0, hash), do: hash
+
+  def encode(data, hash) when is_binary(data) do
+    encode_zeros(data) <> encode(:binary.decode_unsigned(data), hash) 
+  end
+
+  def encode(data, hash) do
+    character = <<Enum.at(alphabet(), rem(data, 58))>>
+    encode(div(data, 58), character <> hash)
+  end
+
+  defp encode_zeros(data, acc \\ []) 
+
+  defp encode_zeros(<<0, data :: bitstring>>, acc) do
+    encode_zeros(data, [1 | acc])
+  end
+
+  defp encode_zeros(_, acc), do: acc |> Enum.join("")
+
+  def decode(data) when is_binary(data) do
+    data
+    |> to_charlist
+    |> decode(0)
+  end
+
+  def decode(_) do
+    raise(ArgumentError, "Please use only base58 encoded binary as input")
+  end
+
+  defp decode([], acc), do: acc
+  defp decode([c | code], acc) do
+     decode(code, (acc * 58) + find_in_alphabet(c))
+  end
+
+  defp find_in_alphabet(char) do
+    case Enum.find_index(alphabet(), &(&1 == char)) do
+      nil   -> raise ArgumentError, "illegal character #{char}"
+      index -> index
+    end
+  end
+end

--- a/lib/block_keys/base58/encoder.ex
+++ b/lib/block_keys/base58/encoder.ex
@@ -1,4 +1,4 @@
-defmodule Base58.Encoder do
+defmodule BlockKeys.Base58.Encoder do
   @btc_alphabet '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
   @xrp_alphabet 'rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz'
 

--- a/lib/block_keys/encoding.ex
+++ b/lib/block_keys/encoding.ex
@@ -6,13 +6,15 @@ defmodule BlockKeys.Encoding do
   @private_version_number <<4, 136, 173, 228>>
   @public_version_number <<4, 136, 178, 30>>
 
+  alias BlockKeys.Base58
+
   def base58_encode(bytes, version_prefix \\ "") do
-    Base58Check.encode58check(version_prefix, bytes)
+    Base58.encode_check(bytes, version_prefix)
   end
 
   def decode_extended_key(key) do
     decoded_key =
-      Base58Check.decode58(key)
+      Base58.decode(key)
       |> :binary.encode_unsigned()
 
     <<
@@ -71,7 +73,7 @@ defmodule BlockKeys.Encoding do
     )
   end
 
-  def encode_public({:error, message} = payload), do: payload
+  def encode_public({:error, _message} = payload), do: payload
 
   def encode_private(%{
         derived_key: derived_key,

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,6 @@ defmodule BlockKeys.MixProject do
       {:secure_random, "~> 0.5"},
       {:libsecp256k1, "~> 0.1.9"},
       {:keccakf1600, "~> 2.0", hex: :keccakf1600_orig},
-      {:base58check, github: "tzumby/base58check"},
       {:excoveralls, "~> 0.10", only: :test}
     ]
   end

--- a/test/block_keys/base58_test.exs
+++ b/test/block_keys/base58_test.exs
@@ -1,9 +1,9 @@
 defmodule Base58Test do
   use ExUnit.Case
 
-  import Base58
+  import BlockKeys.Base58
 
-  doctest Base58
+  doctest BlockKeys.Base58
 
   test "encode/1" do
     assert encode(0) == ""
@@ -25,12 +25,13 @@ defmodule Base58Test do
 
   test "correctly encodes" do
     # https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses
-    assert Base58.encode_check(
+    assert encode_check(
       <<0x01,0x09,0x66,0x77,0x60,0x06,0x95,0x3D,0x55,0x67,0x43,0x9E,0x5E,0x39,0xF8,0x6A,0x0D,0x27,0x3B, 0xEE>>,
        <<0x00>>
      ) == "16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM"
   end
-    @test_hex "1e99423a4ed27608a15a2616a2b0e9e52ced330ac530edcc32c8ffc6a526aedd"
+
+  @test_hex "1e99423a4ed27608a15a2616a2b0e9e52ced330ac530edcc32c8ffc6a526aedd"
   @test_base58 "5J3mBbAH58CpQ3Y5RNJpUKPE62SQ5tfcvU2JpbnkeyhfsYB1Jcn"
 
   test "encode_check/2 accepts integer" do
@@ -53,9 +54,6 @@ defmodule Base58Test do
 
   test "decode_check/1 accepts hex and returns prefix and payload" do
     {prefix, payload} = decode_check(@test_base58, 37)
-    IO.inspect prefix
-    IO.inspect payload
-
     assert Base.encode16(payload, case: :lower) == @test_hex
     assert :binary.decode_unsigned(prefix) == 128
   end

--- a/test/block_keys/base58_test.exs
+++ b/test/block_keys/base58_test.exs
@@ -1,0 +1,98 @@
+defmodule Base58Test do
+  use ExUnit.Case
+
+  import Base58
+
+  doctest Base58
+
+  test "encode/1" do
+    assert encode(0) == ""
+    assert encode(57) == "z"
+    assert encode(1024) == "Jf"
+    assert encode(123456789) == "BukQL"
+    assert encode(<<1, 0>>) == "5R"
+  end
+
+  test "decode/1" do
+    assert decode("") == 0
+    assert decode("z") == 57
+    assert decode("Jf") == 1024
+    assert decode("BukQL") == 123456789
+    assert_raise ArgumentError, fn ->
+      decode(123)
+    end
+  end
+
+  test "correctly encodes" do
+    # https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses
+    assert Base58.encode_check(
+      <<0x01,0x09,0x66,0x77,0x60,0x06,0x95,0x3D,0x55,0x67,0x43,0x9E,0x5E,0x39,0xF8,0x6A,0x0D,0x27,0x3B, 0xEE>>,
+       <<0x00>>
+     ) == "16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM"
+  end
+    @test_hex "1e99423a4ed27608a15a2616a2b0e9e52ced330ac530edcc32c8ffc6a526aedd"
+  @test_base58 "5J3mBbAH58CpQ3Y5RNJpUKPE62SQ5tfcvU2JpbnkeyhfsYB1Jcn"
+
+  test "encode_check/2 accepts integer" do
+    bin = Base.decode16! @test_hex, case: :lower
+    integer = :binary.decode_unsigned(bin)
+    assert encode_check(integer, 128) == @test_base58
+  end
+
+  test "encode_check/2 accepts binary" do
+    data_bin = Base.decode16! @test_hex, case: :lower
+    prefix_bin = :binary.encode_unsigned(128)
+    assert encode_check(data_bin, prefix_bin) == @test_base58
+  end
+
+  test "encode_check/2 accepts hex" do
+    assert encode_check(@test_hex, 128) == @test_base58
+    btc_address = "1EUbuiBzfdq939oPArvPGe6sRcUskoYCexXbRk1R6r2hwNdAP2"
+    assert encode_check(@test_hex, 0) == btc_address
+  end
+
+  test "decode_check/1 accepts hex and returns prefix and payload" do
+    {prefix, payload} = decode_check(@test_base58, 37)
+    IO.inspect prefix
+    IO.inspect payload
+
+    assert Base.encode16(payload, case: :lower) == @test_hex
+    assert :binary.decode_unsigned(prefix) == 128
+  end
+
+  test "decode_check/1 raises if address too long" do
+    assert_raise ArgumentError, fn ->
+      decode_check(@test_base58)
+    end
+  end
+
+  test "decode_check/1 raises if address too short" do
+    assert_raise ArgumentError, fn ->
+      decode_check("1e")
+    end
+  end
+
+  test "decode_check/1 raises when checksum doesn't match" do
+    assert_raise ArgumentError, fn ->
+      decode_check("5J3mBbAH58CpQ3Y5RNJpUKPE62SQ5tfcvU2JpbnkeyhfsYB1Jc")
+    end
+  end
+
+  test "decode_check/1 does not raise for valid address 1" do
+    decode_check("1111111111111111111114oLvT2")
+  end
+
+  test "decode_check/1 does not raise for valid address 2" do
+    decode_check("1AGNa15ZQXAZUgFiqJ2i7Z2DPU2J6hW62i")
+  end
+
+  test "decode_check/1 does not raise for valid address 3" do
+    decode_check("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy")
+  end
+
+  test "decode_check/1 raises on invalid chars in address" do
+    assert_raise ArgumentError, fn ->
+      decode_check("0J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy")
+    end
+  end
+end


### PR DESCRIPTION
Hey @viktmv, thanks for pushing this. The test was failing because the decode_check was returning the data instead of payload. 

```
case valid_checksum?(generated_checksum, checksum) do
  false -> raise ArgumentError, "Checksum is not valid!"
   true  -> {prefix, payload}
end
```