### PR TITLE
Configurable secp256k1 library

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,45 @@ Currently it supports Bitcoin and Ethereum but will be extended to support a [la
 
 For low level details check the [Wiki](https://github.com/AgileAlpha/block_keys/wiki).
 
+## Installation
+
+Add the dependency to your `mix.exs`:
+
+```
+def deps do
+  [
+    {:block_keys, "~> 0.1.2"}
+  ]
+end
+```
+
+### Using a different libsecp256k1 library
+
+By default, this package depends on the [ExThereum's fork of libsecp256k1 C Nif](https://github.com/exthereum/libsecp256k1).
+
+If you prefer, you can either roll your own Crypto module or use another experimental and probably incomplete Rust based Nif
+based on [Parity's pure Rust implementation](https://crates.io/crates/libsecp256k1). 
+
+Add this additional dependency to your `mix.exs`:
+
+```
+def deps do
+  [
+    ...
+    {:rusty_secp256k1, "~> 0.1.6"}
+    ...
+  ]
+end
+```
+
+And configure the package to use it in your `config.exs` or the appropriate env configuration:
+
+```
+config :block_keys, :ec_module, RustySecp256k1
+```
+
+Note that you will need to have Rust installed and configured in order to build the `rusty_secp256k1` dependency. 
+
 ## What is this good for ?
 
 The purpose of HD wallets is to increase anonymity by generating different addresses each time you transact. For Bitcoin this means generating

--- a/config/config.exs
+++ b/config/config.exs
@@ -21,6 +21,8 @@ use Mix.Config
 #     config :logger, level: :info
 #
 
+config :block_keys, :ec_module, :libsecp256k1
+
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment
 # by uncommenting the line below and defining dev.exs, test.exs and such.

--- a/lib/block_keys/base58/encoder.ex
+++ b/lib/block_keys/base58/encoder.ex
@@ -1,16 +1,16 @@
 defmodule BlockKeys.Base58.Encoder do
   @btc_alphabet '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
-  @xrp_alphabet 'rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz'
+  # @xrp_alphabet 'rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz'
 
   # TODO: add alphabet selection
   def alphabet, do: @btc_alphabet
 
   def encode(data, hash \\ "")
-  
+
   def encode(0, hash), do: hash
 
   def encode(data, hash) when is_binary(data) do
-    encode_zeros(data) <> encode(:binary.decode_unsigned(data), hash) 
+    encode_zeros(data) <> encode(:binary.decode_unsigned(data), hash)
   end
 
   def encode(data, hash) do
@@ -18,9 +18,9 @@ defmodule BlockKeys.Base58.Encoder do
     encode(div(data, 58), character <> hash)
   end
 
-  defp encode_zeros(data, acc \\ []) 
+  defp encode_zeros(data, acc \\ [])
 
-  defp encode_zeros(<<0, data :: bitstring>>, acc) do
+  defp encode_zeros(<<0, data::bitstring>>, acc) do
     encode_zeros(data, [1 | acc])
   end
 
@@ -37,13 +37,14 @@ defmodule BlockKeys.Base58.Encoder do
   end
 
   defp decode([], acc), do: acc
+
   defp decode([c | code], acc) do
-     decode(code, (acc * 58) + find_in_alphabet(c))
+    decode(code, acc * 58 + find_in_alphabet(c))
   end
 
   defp find_in_alphabet(char) do
     case Enum.find_index(alphabet(), &(&1 == char)) do
-      nil   -> raise ArgumentError, "illegal character #{char}"
+      nil -> raise ArgumentError, "illegal character #{char}"
       index -> index
     end
   end

--- a/lib/block_keys/crypto.ex
+++ b/lib/block_keys/crypto.ex
@@ -19,11 +19,19 @@ defmodule BlockKeys.Crypto do
 
   # tweak the child key by adding the parent key to it
   def ec_point_addition(parent_key, child_key) do
-    :libsecp256k1.ec_pubkey_tweak_add(parent_key, child_key)
+    ec_module().ec_pubkey_tweak_add(parent_key, child_key)
   end
 
   def public_key(private_key) do
-    {public_key, _} = :crypto.generate_key(:ecdh, :secp256k1, private_key)
+    {:ok, public_key} = ec_module().ec_pubkey_create(private_key, :uncompressed)
     public_key
+  end
+
+  def public_key_decompress(public_key) do
+    ec_module().ec_pubkey_decompress(public_key)
+  end
+
+  defp ec_module do
+    Application.fetch_env!(:block_keys, :ec_module)
   end
 end

--- a/lib/block_keys/ethereum/address.ex
+++ b/lib/block_keys/ethereum/address.ex
@@ -3,7 +3,7 @@ defmodule BlockKeys.Ethereum.Address do
   Converts a public extended key into an Ethereum Address
   """
 
-  alias BlockKeys.Encoding
+  alias BlockKeys.{Encoding, Crypto}
 
   def from_xpub(xpub) do
     xpub
@@ -24,7 +24,8 @@ defmodule BlockKeys.Ethereum.Address do
   defp maybe_decode(key), do: key
 
   defp decompress(key) do
-    {:ok, key} = :libsecp256k1.ec_pubkey_decompress(key)
+    {:ok, key} = Crypto.public_key_decompress(key)
+
     <<_prefix::binary-1, pub_key::binary>> = key
     pub_key
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule BlockKeys.MixProject do
   def project do
     [
       app: :block_keys,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.7",
       description: description(),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule BlockKeys.MixProject do
   def project do
     [
       app: :block_keys,
-      version: "0.1.1",
+      version: "0.1.2",
       elixir: "~> 1.7",
       description: description(),
       start_permanent: Mix.env() == :prod,
@@ -41,9 +41,9 @@ defmodule BlockKeys.MixProject do
   defp deps do
     [
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},
-      {:libsecp256k1, "~> 0.1.9"},
       {:keccakf1600, "~> 2.0", hex: :keccakf1600_orig},
-      {:excoveralls, "~> 0.10", only: :test}
+      {:excoveralls, "~> 0.10", only: :test},
+      {:libsecp256k1, "~> 0.1.9"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,4 @@
 %{
-  "base58check": {:git, "https://github.com/tzumby/base58check.git", "8e1d7d832d49162c9628534e400b477463533f1b", []},
   "certifi": {:hex, :certifi, "2.4.2", "75424ff0f3baaccfd34b1214184b6ef616d89e420b258bb0a5ea7d7bc628f7f0", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
@@ -16,7 +15,6 @@
   "mix_erlang_tasks": {:hex, :mix_erlang_tasks, "0.1.0", "36819fec60b80689eb1380938675af215565a89320a9e29c72c70d97512e4649", [:mix], [], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
-  "secure_random": {:hex, :secure_random, "0.5.1", "c5532b37c89d175c328f5196a0c2a5680b15ebce3e654da37129a9fe40ebf51b", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }

--- a/test/block_keys/bitcoin/address_test.exs
+++ b/test/block_keys/bitcoin/address_test.exs
@@ -1,4 +1,4 @@
-defmodule AddressTest do
+defmodule BitcoinAddressTest do
   use ExUnit.Case, async: true
 
   alias BlockKeys.Bitcoin.Address

--- a/test/block_keys/ethereum/address_test.exs
+++ b/test/block_keys/ethereum/address_test.exs
@@ -1,0 +1,20 @@
+defmodule EthereumAddressTest do
+  use ExUnit.Case, async: true
+
+  alias BlockKeys.Ethereum.Address
+  alias BlockKeys.CKD
+
+  test "address from mnemonic" do
+    root_key =
+      BlockKeys.from_mnemonic(
+        "nurse grid sister metal flock choice system control about mountain sister rapid hundred render shed chicken print cover tape sister zero bronze tattoo stairs"
+      )
+
+    assert root_key ==
+             "xprv9s21ZrQH143K35qGjQ6GG1wGHFZP7uCZA1WBdUJA8vBZqESQXQGA4A9d4eve5JqWB5m8YTMcNe8cc7c3FVzDGNcmiabi9WQycbFeEvvJF2D"
+
+    assert CKD.derive(root_key, "M/44'/60'/0'/0/0")
+           |> Address.from_xpub() ==
+             "0x73bb50c828fd325c011d740fde78d02528826156"
+  end
+end


### PR DESCRIPTION
This fixes #5. The original dependency is still the default in order to preserve backwards compatibility. I tested and documented the use of my own [Rust NIF](https://github.com/tzumby/rusty_secp256k1/) as an example alternative to `libsecp256k1`. 